### PR TITLE
feature/fixPwdReset

### DIFF
--- a/db/user/getUserByEmail.sql
+++ b/db/user/getUserByEmail.sql
@@ -1,0 +1,10 @@
+SELECT
+  user_id,
+  username,
+  first_name,
+  last_name,
+  email
+FROM
+  users
+WHERE
+  email = $1;

--- a/db/user/getUserByUsername.sql
+++ b/db/user/getUserByUsername.sql
@@ -1,0 +1,10 @@
+SELECT
+  user_id,
+  username,
+  first_name,
+  last_name,
+  email
+FROM
+  users
+WHERE
+  username = $1;

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -10,10 +10,10 @@ module.exports = {
       try {
         const salt = await bcrypt.genSalt(10);
         const hash = await bcrypt.hash(password, salt);
-        const storedUserEmail = await db.user.getUser(emailFiltered);
+        const storedUserEmail = await db.user.getUserByEmail(emailFiltered);
         if (storedUserEmail.length === 0) {
           try {
-            const storedUserUsername = await db.user.getUser(usernameFiltered);
+            const storedUserUsername = await db.user.getUserByUsername(usernameFiltered);
             if (storedUserUsername.length === 0) {
               try {
                 const user_id = await db.user.register(emailFiltered, usernameFiltered, first_name, last_name, hash);

--- a/server/controllers/playerController.js
+++ b/server/controllers/playerController.js
@@ -19,17 +19,6 @@ module.exports = {
   //     return res.sendStatus(500)
   //   }
   // },
-  getPlayerGameReview: async (req, res) => {
-    try {
-      const db = req.app.get('db');
-      const userID = req.session.user.user_id;
-      const gameID = req.params.id;
-      const reviews = await db.player.getPlayerGameReview(userID, gameID);
-      return res.status(200).send(reviews);
-    } catch (err) {
-      return res.sendStatus(500);
-    }
-  },
   getAllPlayersTotalPlays: async (req, res) => {
     try {
       const db = req.app.get('db');

--- a/server/controllers/userGamesController.js
+++ b/server/controllers/userGamesController.js
@@ -44,7 +44,7 @@ module.exports = {
       const gameID = req.body.gameID;
       const review = req.body.review;
       await db.userGames.updateReview(userID, gameID, review);
-      return res.sendStatus(200);
+      return res.status(200).send(review);
     } catch (err) {
       return res.sendStatus(500)
     }

--- a/server/controllers/userInfoController.js
+++ b/server/controllers/userInfoController.js
@@ -8,35 +8,43 @@ module.exports = {
         const db = req.app.get('db');
         const { email } = req.body;
         const emailFiltered = email.toLowerCase().replace(/\s/g, '');
-        const storedUser = await db.user.getUser(emailFiltered);
-        if (storedUser.length === 0) {
-          const user_id = req.session.user.user_id;
-          try {
-            await db.userInfo.editEmail(user_id, emailFiltered);
-            req.session.user = { ...req.session.user, email: emailFiltered };
-            return res.status(200).send(req.session.user);
-          } catch (err) {
-            return res.sendStatus(500);
+        const storedUser = await db.user.getUserByEmail(emailFiltered);
+        if (email) {
+          if (storedUser.length === 0) {
+            const user_id = req.session.user.user_id;
+            try {
+              await db.userInfo.editEmail(user_id, emailFiltered);
+              req.session.user = { ...req.session.user, email: emailFiltered };
+              return res.status(200).send(req.session.user);
+            } catch (err) {
+              return res.sendStatus(500);
+            }
+          } else {
+            return res.status(400).send('email');
           }
         } else {
-          return res.sendStatus(403);
+          return res.status(400).send('incomplete');
         }
       case 'username':
         const db1 = req.app.get('db');
         const { username } = req.body;
         const usernameFiltered = username.toLowerCase().replace(/\s/g, '');
-        const storedUser1 = await db1.user.getUser(usernameFiltered);
-        if (storedUser1.length === 0) {
-          const user_id1 = req.session.user.user_id;
-          try {
-            await db1.userInfo.editUsername(user_id1, usernameFiltered);
-            req.session.user = { ...req.session.user, username: usernameFiltered };
-            return res.status(200).send(req.session.user);
-          } catch (err) {
-            return res.sendStatus(500);
+        const storedUser1 = await db1.user.getUserByUsername(usernameFiltered);
+        if (username) {
+          if (storedUser1.length === 0) {
+            const user_id1 = req.session.user.user_id;
+            try {
+              await db1.userInfo.editUsername(user_id1, usernameFiltered);
+              req.session.user = { ...req.session.user, username: usernameFiltered };
+              return res.status(200).send(req.session.user);
+            } catch (err) {
+              return res.sendStatus(500);
+            }
+          } else {
+            return res.status(400).send('username');
           }
         } else {
-          return res.sendStatus(403);
+          return res.status(400).send('incomplete');
         }
       case 'password':
         const db2 = req.app.get('db');

--- a/server/index.js
+++ b/server/index.js
@@ -54,7 +54,7 @@ app.delete('/api/usergame/:id', authMiddleware.authorize, userGames.deleteGame);
 
 // //UserInfo endpoints -> My Account
 app.put('/api/user/:editType', authMiddleware.authorize, userInfo.editInfo);
-app.put('/api/user/delete', authMiddleware.authorize, userInfo.deleteUser);
+app.delete('/api/user/delete', authMiddleware.authorize, userInfo.deleteUser);
 
 // Password Reset Endpoints
 app.put('/api/pwdReset/req', passwordReset.resetPwdEmail);
@@ -62,8 +62,6 @@ app.put('/api/pwdReset/submit/:token', passwordReset.processReset);
 // //Player endpoints
 // Item Display //User Graph
 app.get('/api/player/playcount/:id', player.getPlayerTotalPlays);
-// Game Display
-app.get('/api/player/reviews/:id', player.getPlayerGameReview);
 // Leaderboard
 app.get('/api/player/leaderboard', player.getAllPlayersTotalPlays);
 

--- a/src/components/User/ItemDisplay.tsx
+++ b/src/components/User/ItemDisplay.tsx
@@ -2,35 +2,34 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import React, { useState, useEffect, SyntheticEvent } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '../../redux/store';
-import { UserGameProps } from 'customTypes';
+import { GameDispProps, OptionNoName } from 'customTypes';
 import Button from '../StyledComponents/Button';
 import HTMLReactParser from 'html-react-parser';
 import mechCatProcessor from '../mechCatProccessor';
 import Rating from '../StyledComponents/Rating';
-import { getUserGames } from '../../redux/userGameReducer';
-import { RouteComponentProps } from 'react-router-dom';
+import { getUserGames, UserGame } from '../../redux/userGameReducer';
 
-const ItemDisplay: React.FC<UserGameProps & RouteComponentProps> = (
-  props: UserGameProps & RouteComponentProps
-): JSX.Element => {
-  const [gameID] = useState(props.location.state.userGame.game_id);
-  const [yearPublished] = useState(props.location.state.userGame.year_published);
-  const [minPlayers] = useState(props.location.state.userGame.min_players);
-  const [maxPlayer] = useState(props.location.state.userGame.max_players);
-  const [minAge] = useState(props.location.state.userGame.min_age);
-  const [mechanics] = useState(props.location.state.userGame.mechanics);
-  const [categories] = useState(props.location.state.userGame.categories);
+const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element => {
+  const [gameID] = useState(props.match.params.id);
+  const [yearPublished, setYearPublished] = useState('');
+  const [minPlayers, setMinPlayers] = useState(0);
+  const [maxPlayer, setMaxPlayers] = useState(0);
+  const [minAge, setMinAge] = useState(0);
+  const [maxAge, setMaxAge] = useState(0);
+  const [mechanicsState, setMechanics] = useState<OptionNoName[]>([]);
+  const [categoriesState, setCategories] = useState<OptionNoName[]>([]);
   const [mechanicsProc, setMechanicsProc] = useState('');
   const [categoriesProc, setCategoriesProc] = useState('');
-  const [description] = useState(props.location.state.userGame.description);
-  const [imageUrl] = useState(props.location.state.userGame.image_url);
-  const [name] = useState(props.location.state.userGame.name);
-  const [playCount, setPlayCount] = useState(props.location.state.userGame.play_count);
-  const [rating, setRating] = useState(props.location.state.userGame.rating);
+  const [description, setDescription] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [name, setName] = useState('');
+  const [playCount, setPlayCount] = useState(0);
+  const [rating, setRating] = useState(0);
   const [addEdit, setAddEdit] = useState(false);
   const [input, setInput] = useState<string>('');
   const [editing, setEditing] = useState(false);
 
+  const userGames = useSelector((state: RootState) => state.userGameReducer.userGames);
   const mechanicsLib = useSelector((state: RootState) => state.meccatReducer.mechanic);
   const categoriesLib = useSelector((state: RootState) => state.meccatReducer.category);
 
@@ -39,14 +38,43 @@ const ItemDisplay: React.FC<UserGameProps & RouteComponentProps> = (
   useEffect((): void => {
     getReview();
     const { mechanicsProcessed, categoriesProcessed } = mechCatProcessor(
-      mechanics,
-      categories,
+      mechanicsState,
+      categoriesState,
       mechanicsLib,
       categoriesLib
     );
     setMechanicsProc(mechanicsProcessed);
     setCategoriesProc(categoriesProcessed);
   }, []);
+
+  useEffect((): void => {
+    const {
+      name,
+      play_count,
+      rating,
+      review,
+      image_url,
+      description,
+      mechanics,
+      categories,
+      min_age,
+      max_age,
+      min_players,
+      max_players,
+      year_published
+    } = userGames.filter((el: UserGame) => el.game_id === gameID ? el : {});
+
+    setYearPublished(year_published);
+    setMinPlayers(min_players);
+    setMaxPlayers(max_players);
+    setMinAge(min_age);
+    setMaxAge(max_age);
+    setMechanics(mechanics);
+    setCategories(categories);
+    setDescription(description);
+    setImageUrl(image_url);
+    setName(name);
+  }, [userGames]);
 
   const increasePlayCount = () => {
     axios

--- a/src/components/User/ItemDisplay.tsx
+++ b/src/components/User/ItemDisplay.tsx
@@ -8,14 +8,16 @@ import HTMLReactParser from 'html-react-parser';
 import mechCatProcessor from '../mechCatProccessor';
 import Rating from '../StyledComponents/Rating';
 import { getUserGames, UserGame } from '../../redux/userGameReducer';
+import { RouteComponentProps } from 'react-router-dom';
 
-const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouterProps): JSX.Element => {
+const ItemDisplay: React.FC<GameDispProps & RouteComponentProps> = (
+  props: GameDispProps & RouteComponentProps
+): JSX.Element => {
   const [gameID] = useState(props.match.params.id);
   const [yearPublished, setYearPublished] = useState(0);
   const [minPlayers, setMinPlayers] = useState(0);
   const [maxPlayer, setMaxPlayers] = useState(0);
   const [minAge, setMinAge] = useState(0);
-  const [maxAge, setMaxAge] = useState(0);
   const [mechanicsState, setMechanics] = useState<OptionNoName[]>([]);
   const [categoriesState, setCategories] = useState<OptionNoName[]>([]);
   const [mechanicsProc, setMechanicsProc] = useState('');
@@ -26,7 +28,7 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
   const [playCount, setPlayCount] = useState(0);
   const [rating, setRating] = useState(0);
   const [addEdit, setAddEdit] = useState(false);
-  const [review, setReview] = useState<string>('');
+  const [review, setReview] = useState('');
   const [editing, setEditing] = useState(false);
 
   const userGames = useSelector((state: RootState) => state.userGameReducer.userGames);
@@ -36,22 +38,22 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
   const dispatch = useDispatch();
 
   useEffect((): void => {
-    getReview();
-    const { mechanicsProcessed, categoriesProcessed } = mechCatProcessor(
-      mechanicsState,
-      categoriesState,
-      mechanicsLib,
-      categoriesLib
-    );
-    setMechanicsProc(mechanicsProcessed);
-    setCategoriesProc(categoriesProcessed);
-  }, []);
+    if (mechanicsLib && categoriesLib) {
+      const { mechanicsProcessed, categoriesProcessed } = mechCatProcessor(
+        mechanicsState,
+        categoriesState,
+        mechanicsLib,
+        categoriesLib
+      );
+      setMechanicsProc(mechanicsProcessed);
+      setCategoriesProc(categoriesProcessed);
+    }
+  }, [mechanicsState, categoriesState, mechanicsLib, categoriesLib]);
 
   useEffect((): void => {
     const userGame: UserGame[] = userGames.filter((el: UserGame) => {
       return el.game_id === gameID ? el : {};
     });
-
     const {
       name,
       play_count,
@@ -62,7 +64,6 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
       mechanics,
       categories,
       min_age,
-      max_age,
       min_players,
       max_players,
       year_published
@@ -72,15 +73,15 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
     setMinPlayers(min_players);
     setMaxPlayers(max_players);
     setMinAge(min_age);
-    setMaxAge(max_age);
-    setMechanicsProc(mechanics);
-    setCategoriesProc(categories);
+    setMechanics(mechanics);
+    setCategories(categories);
     setDescription(description);
     setImageUrl(image_url);
     setName(name);
     setPlayCount(play_count);
     setRating(rating);
-    setReview(review);
+    setReview(review ? review : '');
+    review ? setAddEdit(true) : setAddEdit(false);
   }, [userGames]);
 
   const increasePlayCount = () => {
@@ -109,14 +110,14 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
         return axios
           .put('/api/usergame/rating', { gameID, rating: rating + 1 })
           .then((res: AxiosResponse<{ rating: string }>) => {
-            setRating(res.data.rating);
+            setRating(Number.parseInt(res.data.rating));
           })
           .catch((err: AxiosError) => console.log(err));
       case 'dec':
         return axios
           .put('/api/usergame/rating', { gameID, rating: rating - 1 })
           .then((res: AxiosResponse<{ rating: string }>) => {
-            setRating(res.data.rating);
+            setRating(Number.parseInt(res.data.rating));
           })
           .catch((err: AxiosError) => console.log(err));
       default:
@@ -124,15 +125,10 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
     }
   };
   const postReview = () => {
-    axios.put(`/api/usergame/review`, { gameID, review });
-  };
-
-  const getReview = (): void => {
     axios
-      .get(`/api/player/reviews/${gameID}`)
-      .then((res: AxiosResponse<[{ review: string | null }]>) => {
-        setReview(res.data[0].review ? res.data[0].review : '');
-        res.data[0].review ? setAddEdit(true) : setAddEdit(false);
+      .put(`/api/usergame/review`, { gameID, review })
+      .then((res: AxiosResponse<{ review: string }>) => {
+        setReview(res.data.review);
       })
       .catch((err) => console.log(err));
   };
@@ -142,7 +138,6 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouter
     if (editing) {
       setEditing(false);
       postReview();
-      getReview();
     } else {
       setEditing(true);
     }

--- a/src/components/User/ItemDisplay.tsx
+++ b/src/components/User/ItemDisplay.tsx
@@ -9,9 +9,9 @@ import mechCatProcessor from '../mechCatProccessor';
 import Rating from '../StyledComponents/Rating';
 import { getUserGames, UserGame } from '../../redux/userGameReducer';
 
-const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element => {
+const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps & ReactRouterProps): JSX.Element => {
   const [gameID] = useState(props.match.params.id);
-  const [yearPublished, setYearPublished] = useState('');
+  const [yearPublished, setYearPublished] = useState(0);
   const [minPlayers, setMinPlayers] = useState(0);
   const [maxPlayer, setMaxPlayers] = useState(0);
   const [minAge, setMinAge] = useState(0);
@@ -26,7 +26,7 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element
   const [playCount, setPlayCount] = useState(0);
   const [rating, setRating] = useState(0);
   const [addEdit, setAddEdit] = useState(false);
-  const [input, setInput] = useState<string>('');
+  const [review, setReview] = useState<string>('');
   const [editing, setEditing] = useState(false);
 
   const userGames = useSelector((state: RootState) => state.userGameReducer.userGames);
@@ -48,6 +48,10 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element
   }, []);
 
   useEffect((): void => {
+    const userGame: UserGame[] = userGames.filter((el: UserGame) => {
+      return el.game_id === gameID ? el : {};
+    });
+
     const {
       name,
       play_count,
@@ -62,18 +66,21 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element
       min_players,
       max_players,
       year_published
-    } = userGames.filter((el: UserGame) => el.game_id === gameID ? el : {});
+    } = userGame[0];
 
     setYearPublished(year_published);
     setMinPlayers(min_players);
     setMaxPlayers(max_players);
     setMinAge(min_age);
     setMaxAge(max_age);
-    setMechanics(mechanics);
-    setCategories(categories);
+    setMechanicsProc(mechanics);
+    setCategoriesProc(categories);
     setDescription(description);
     setImageUrl(image_url);
     setName(name);
+    setPlayCount(play_count);
+    setRating(rating);
+    setReview(review);
   }, [userGames]);
 
   const increasePlayCount = () => {
@@ -117,14 +124,14 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element
     }
   };
   const postReview = () => {
-    axios.put(`/api/usergame/review`, { gameID, review: input });
+    axios.put(`/api/usergame/review`, { gameID, review });
   };
 
   const getReview = (): void => {
     axios
       .get(`/api/player/reviews/${gameID}`)
       .then((res: AxiosResponse<[{ review: string | null }]>) => {
-        setInput(res.data[0].review ? res.data[0].review : '');
+        setReview(res.data[0].review ? res.data[0].review : '');
         res.data[0].review ? setAddEdit(true) : setAddEdit(false);
       })
       .catch((err) => console.log(err));
@@ -174,8 +181,8 @@ const ItemDisplay: React.FC<GameDispProps> = (props: GameDispProps): JSX.Element
             role="textbox"
             rows={5}
             id="review"
-            value={input}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setInput(e.target.value)}
+            value={review}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>): void => setReview(e.target.value)}
             placeholder="write review here"
             name="review"
             disabled={!editing}></textarea>

--- a/src/components/User/MyAccount.tsx
+++ b/src/components/User/MyAccount.tsx
@@ -73,11 +73,13 @@ const MyAccount: React.FC<RouteComponentProps> = (props: RouteComponentProps) =>
     }
     axios
       .put(`api/user/${param}`, body)
-      .then((res: AxiosResponse<User>) => {
-        const user = res.data;
-        dispatch({ type: 'UPDATE_USER', payload: user });
-        setEditing();
-      })
+      .then(
+        async (res: AxiosResponse<User>): Promise<void> => {
+          const user = res.data;
+          dispatch({ type: 'UPDATE_USER', payload: user });
+          setEditing();
+        }
+      )
       .catch((err) => console.log(err));
   };
 

--- a/src/components/User/MyAccount.tsx
+++ b/src/components/User/MyAccount.tsx
@@ -5,6 +5,7 @@ import { RootState } from '../../redux/store';
 import { RouteComponentProps } from 'react-router-dom';
 import Button from '../StyledComponents/Button';
 import { User } from 'customTypes';
+import { toast, ToastContainer } from 'react-toastify';
 
 const MyAccount: React.FC<RouteComponentProps> = (props: RouteComponentProps) => {
   const user = useSelector((state: RootState) => state.userReducer);
@@ -84,7 +85,7 @@ const MyAccount: React.FC<RouteComponentProps> = (props: RouteComponentProps) =>
         break;
     }
     axios
-      .put(`api/user/${param}`, body)
+      .put(`/api/user/${param}`, body)
       .then(
         async (res: AxiosResponse<User>): Promise<void> => {
           const user = res.data;
@@ -92,9 +93,24 @@ const MyAccount: React.FC<RouteComponentProps> = (props: RouteComponentProps) =>
           setEditing();
         }
       )
-      .catch((err) => console.log(err));
+      .catch((err) => {
+        if (err.response.data === 'email') {
+          toast.error(
+            'An account with the email you entered already exists in our database. Please use a different email.'
+          );
+        } else if (err.response.data === 'username') {
+          toast.error(
+            'An account with the username you entered already exists in our database. Please select a different username.'
+          );
+        } else if (err.response.data === 'incomplete') {
+          toast.error('You must have both a unique username and email.');
+        } else {
+          toast.error(
+            'A problem was encountered while attempting to change your credentials. Please try logging out then logging back in.'
+          );
+        }
+      });
   };
-
   const confirmDelete = (): void => {
     axios
       .delete('/api/user/delete')
@@ -114,6 +130,7 @@ const MyAccount: React.FC<RouteComponentProps> = (props: RouteComponentProps) =>
 
   return (
     <div className="myAccount">
+      <ToastContainer />
       <div className="myAccountContainer">
         <h2>account</h2>
         {!isEditingUsername ? (

--- a/src/components/User/ShelfItem.tsx
+++ b/src/components/User/ShelfItem.tsx
@@ -4,7 +4,7 @@ import { UserGame } from '../../redux/userGameReducer';
 import Rating from '../StyledComponents/Rating';
 
 const ShelfItem: React.FC<UserGame> = (props: UserGame): JSX.Element => {
-  return (
+  return props.game_id ? (
     <div className="shelf">
       <section className="shelfItemBox">
         <div className="nameFlex">
@@ -28,6 +28,8 @@ const ShelfItem: React.FC<UserGame> = (props: UserGame): JSX.Element => {
         </div>
       </section>
     </div>
+  ) : (
+    <>,</>
   );
 };
 

--- a/src/components/User/ShelfItem.tsx
+++ b/src/components/User/ShelfItem.tsx
@@ -11,7 +11,7 @@ const ShelfItem: React.FC<UserGame> = (props: UserGame): JSX.Element => {
           <h3>{props.name}</h3>
         </div>
         <div className="shelfItemFlex">
-          <Link to={{ pathname: `/usergame/${props.game_id}`, state: { userGame: props } }} className="linkContainer">
+          <Link to={`/usergame/${props.game_id}`} className="linkContainer">
             <div className="overlay">
               <p className="infoText">info</p>
             </div>

--- a/src/components/User/User.tsx
+++ b/src/components/User/User.tsx
@@ -5,7 +5,6 @@ import LeaderBoard from '../Header/LeaderBoard';
 import { RootState } from '../../redux/store';
 import axios from 'axios';
 import { UserGame } from '../../redux/userGameReducer';
-// import {getUser} from '../../redux/userReducer';
 import { getUserGames } from '../../redux/userGameReducer';
 
 const User: React.FC = () => {
@@ -20,7 +19,7 @@ const User: React.FC = () => {
   useEffect((): void => {
     getPlayerStats();
     dispatch(getUserGames());
-  }, []);
+  }, [userID]);
 
   const getPlayerStats = () => {
     axios.get(`/api/player/playcount/${userID}`).then((res) => {

--- a/src/custom-types.d.ts
+++ b/src/custom-types.d.ts
@@ -36,14 +36,6 @@ declare module 'customTypes' {
     };
   };
 
-  export type UserGameProps = {
-    location: {
-      state: {
-        userGame: UserGame;
-      };
-    };
-  };
-
   export type GameBoxProps = {
     thumbGame: ThumbGame;
   };
@@ -82,9 +74,11 @@ declare module 'customTypes' {
     rating: number;
     review: string;
   };
+
   export type ReviewProps = {
     game_id: string;
   };
+
   export type UserReview = {
     userID?: number;
     gameID?: string;

--- a/src/redux/userGameReducer.tsx
+++ b/src/redux/userGameReducer.tsx
@@ -28,6 +28,7 @@ export interface UserGame {
   mechanics: string;
   categories: string;
   min_age: number;
+  max_age: number;
   min_players: number;
   max_players: number;
   year_published: number;

--- a/src/redux/userGameReducer.tsx
+++ b/src/redux/userGameReducer.tsx
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { DBGame } from 'customTypes';
+import { DBGame, OptionNoName } from 'customTypes';
 import dotenv from 'dotenv';
 dotenv.config();
 const { REACT_APP_CLIENT_ID } = process.env;
@@ -9,8 +9,8 @@ export interface APIGame {
   name: string;
   image_url: string;
   description: string;
-  mechanics: string;
-  categories: string;
+  mechanics: OptionNoName[];
+  categories: OptionNoName[];
   min_age: number;
   min_players: number;
   max_players: number;
@@ -25,10 +25,9 @@ export interface UserGame {
   review: string;
   image_url: string;
   description: string;
-  mechanics: string;
-  categories: string;
+  mechanics: OptionNoName[];
+  categories: OptionNoName[];
   min_age: number;
-  max_age: number;
   min_players: number;
   max_players: number;
   year_published: number;
@@ -48,8 +47,8 @@ const initialState: GameState = {
       review: '',
       image_url: '',
       description: '',
-      mechanics: '',
-      categories: '',
+      mechanics: [],
+      categories: [],
       min_age: 0,
       min_players: 0,
       max_players: 0,
@@ -105,8 +104,8 @@ const apiLogic = async (): Promise<UserGame[]> => {
         name: '',
         image_url: '',
         description: '',
-        mechanics: '',
-        categories: '',
+        mechanics: [],
+        categories: [],
         min_age: 0,
         min_players: 0,
         max_players: 0,


### PR DESCRIPTION
Removed getPlayerReview endpoint and associated call within item display  - it was unnecessary given the infomration comes back when user games are requested - , removed associated redundant axios call from item display, took state dependencies off of props.location.state and relocated to userGamesReducer to allow for refreshing, fixed issue with existing username and email checking - formerly one query to check for both preventing users from using a username that might also be someone else's email -  on backend, fixed type issues in userGamesReducer and elsewhere, added more descriptive error reporting already found on register to userInfoController to userInfoController and error handling in axios call on frontend, fixed play count issue in gameLibrary - no useEffect on userID change - , fix delete functionality axios call in MyAccount and backend endpoint type  - put-> delete -, fix issue where empty game loaded temporarily then disappeared in game library when no games added. 